### PR TITLE
fix(signalk): update image to match preloaded version

### DIFF
--- a/apps/signalk/docker-compose.json
+++ b/apps/signalk/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "signalk",
-      "image": "cr.signalk.io/signalk/signalk-server:latest-24.x",
+      "image": "signalk/signalk-server:v2.17.2-24.x",
       "isMain": true,
       "internalPort": "3000",
       "volumes": [


### PR DESCRIPTION
## Summary
- Updates Signal K Docker image version to match the preloaded image in halos-pi-gen
- Changes image from `cr.signalk.io/signalk/signalk-server:latest-24.x` to `signalk/signalk-server:v2.17.2-24.x`

## Details
The app store was using an image reference that didn't match the version preloaded during image build in halos-pi-gen. The preloaded version uses `signalk/signalk-server:v2.17.2-24.x` which corresponds to Signal K v2.17.2 running on Node 24.

This ensures users get consistent Signal K versions whether they use the preloaded image or install from the app store.

## Test plan
- [ ] Verify app store installs Signal K v2.17.2-24.x
- [ ] Verify preloaded image matches app store version
- [ ] Test Signal K functionality after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)