### PR TITLE
fix(grafana): change default port to 3001

### DIFF
--- a/apps/grafana/config.json
+++ b/apps/grafana/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../schema.json",
   "name": "Grafana",
-  "port": 8160,
+  "port": 3001,
   "available": true,
   "exposable": true,
   "dynamic_config": true,


### PR DESCRIPTION
## Summary
- Changes Grafana's default port from 8160 to 3001

## Details

Port 3001 is the typical convention for Grafana in Signal K-related marine setups. This makes the default configuration more consistent with common marine installations.

**Change:**
- Before: Port 8160
- After: Port 3001

This aligns with standard Signal K ecosystem ports:
- Signal K Server: 3000
- Grafana: 3001
- OpenCPN: 3020

## Test plan
- [x] Verified JSON is valid
- [ ] Test Grafana installation on port 3001

🤖 Generated with [Claude Code](https://claude.com/claude-code)