### PR TITLE
fix(opencpn): change internal port to 3001 for HTTPS support

### DIFF
--- a/apps/opencpn/config.json
+++ b/apps/opencpn/config.json
@@ -4,7 +4,7 @@
   "available": true,
   "short_desc": "Full-featured chartplotter accessible via web browser",
   "author": "OpenCPN Development Team",
-  "port": 3020,
+  "port": 3021,
   "categories": [
     "utilities",
     "network"

--- a/apps/opencpn/docker-compose.json
+++ b/apps/opencpn/docker-compose.json
@@ -4,7 +4,7 @@
       "name": "opencpn",
       "image": "ghcr.io/hatlabs/opencpn-docker:latest",
       "isMain": true,
-      "internalPort": "3000",
+      "internalPort": "3001",
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/config",


### PR DESCRIPTION
## Summary
- Change OpenCPN internal port from 3000 to 3001 to enable HTTPS
- Update external port from 3020 to 3021 to match

## Reason
WebRTC does not work on unencrypted ports. Port 3000 is configured for HTTP while port 3001 uses HTTPS, which is required for WebRTC functionality in OpenCPN.

## Changes
- `apps/opencpn/config.json`: port 3020 → 3021
- `apps/opencpn/docker-compose.json`: internalPort 3000 → 3001

## Test plan
- [ ] Verify OpenCPN starts correctly on port 3021
- [ ] Verify HTTPS is enabled and WebRTC functionality works
- [ ] Confirm no port conflicts with other marine apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)