### PR TITLE
fix(opencpn): enable HTTPS in config

### DIFF
--- a/apps/opencpn/config.json
+++ b/apps/opencpn/config.json
@@ -5,6 +5,7 @@
   "short_desc": "Full-featured chartplotter accessible via web browser",
   "author": "OpenCPN Development Team",
   "port": 3021,
+  "https": true,
   "categories": [
     "utilities",
     "network"


### PR DESCRIPTION
## Summary
- Add `https: true` flag to OpenCPN config.json

## Reason
Completes the HTTPS setup from PR #12. The `https` flag needs to be explicitly set in the config to properly enable HTTPS for the OpenCPN app.

## Changes
- `apps/opencpn/config.json`: Add `"https": true` field

## Test plan
- [ ] Verify OpenCPN uses HTTPS when accessed on port 3021
- [ ] Confirm WebRTC functionality works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)