### PR TITLE
chore: run tests only on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Remove `push` trigger from test workflow
- Tests now only run on pull requests

## Reason
Tests already run on PRs, so there's no need to run them again when the PR is merged to main. This reduces unnecessary CI usage and clutter in the Actions tab.

## Changes
- `.github/workflows/test.yml`: Remove `push: branches: [main]` trigger

## Test plan
- [x] Verify this PR triggers the test workflow (it should)
- [ ] After merging, verify that no test workflow runs on the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)