### PR TITLE
feat(avnav): upgrade to 20250901 with mapproxy support

### DIFF
--- a/apps/avnav/config.json
+++ b/apps/avnav/config.json
@@ -4,14 +4,14 @@
   "available": true,
   "short_desc": "Open-source marine navigation software for chartplotting",
   "author": "Andreas Vogel",
-  "port": 3011,
+  "port": 8080,
   "categories": [
     "utilities",
     "network"
   ],
-  "description": "AvNav is a free and open-source navigation software designed for sailors and boaters. It provides a full-featured chartplotter with support for various chart formats, waypoint management, routing, and integration with marine data sources like Signal K. Perfect for turning your Raspberry Pi into a dedicated navigation computer.",
+  "description": "AvNav is a free and open-source navigation software designed for sailors and boaters. It provides a full-featured chartplotter with support for various chart formats, waypoint management, routing, and integration with marine data sources like Signal K. Includes mapproxy plugin for chart serving and o-charts support for commercial chart formats.",
   "tipi_version": 3,
-  "version": "20250822",
+  "version": "20250901",
   "source": "https://github.com/wellenvogel/avnav",
   "website": "https://www.wellenvogel.net/software/avnav/docs/",
   "exposable": true,

--- a/apps/avnav/docker-compose.json
+++ b/apps/avnav/docker-compose.json
@@ -2,31 +2,26 @@
   "services": [
     {
       "name": "avnav",
-      "image": "ghcr.io/hatlabs/avnav-docker:20250822",
+      "image": "xfreex/avnav-daily:20250901",
       "isMain": true,
       "internalPort": "8080",
+      "networkMode": "host",
+      "privileged": true,
+      "user": "1000:1000",
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data",
-          "containerPath": "/data"
-        },
-        {
-          "hostPath": "${APP_DATA_DIR}/charts",
-          "containerPath": "/charts"
-        },
-        {
-          "hostPath": "${APP_DATA_DIR}/config",
-          "containerPath": "/config"
+          "containerPath": "/var/lib/avnav"
         },
         {
           "hostPath": "/dev",
           "containerPath": "/dev"
         }
       ],
-      "extraHosts": [
-        "host.docker.internal:host-gateway"
-      ],
-      "environment": {}
+      "environment": {
+        "UID": 1000,
+        "GID": 1000
+      }
     }
   ]
 }

--- a/apps/avnav/metadata/description.md
+++ b/apps/avnav/metadata/description.md
@@ -14,18 +14,21 @@ AvNav is a free and open-source navigation software designed specifically for re
 - **Responsive Design**: Touch-optimized interface works on phones, tablets, and computers
 - **Offline Operation**: Full functionality without internet connection once charts are loaded
 - **Extensible**: Plugin system for additional features and customizations
+- **MapProxy Plugin**: Built-in chart server for serving maps to other applications
+- **O-Charts Support**: Full support for commercial o-charts chart format
 
 ## Default Configuration
 
-- **Web Interface**: Port 3011 (HTTP)
-- **Signal K Connection**: Pre-configured to connect to Signal K on port 3000
-- **Data Storage**: Persistent storage for charts, waypoints, tracks, and configuration
+- **Web Interface**: Port 8080 (HTTP)
+- **Signal K Connection**: Can connect to Signal K on port 3000
+- **Data Storage**: Persistent storage at `/var/lib/avnav` for charts, waypoints, tracks, and configuration
+- **Network Mode**: Host networking for better device discovery and multicast support
 
-After installation, access AvNav at `http://your-device-ip:3011`.
+After installation, access AvNav at `http://your-device-ip:8080`.
 
 ## Getting Started
 
-1. **Access the Interface**: Navigate to port 3011 on your device
+1. **Access the Interface**: Navigate to port 8080 on your device
 2. **Upload Charts**: Use the web interface to upload nautical charts (supports various formats including MBTiles, gemf, xml)
 3. **Configure Data Sources**:
    - If Signal K is installed, AvNav will automatically connect


### PR DESCRIPTION
## Summary
- **AvNav**: Upgrade to version 20250901 with MapProxy plugin and O-Charts support
- **CI**: Optimize test workflow to run only on pull requests

Closes hatlabs/avnav-docker#1

## AvNav Changes
- Switch to `xfreex/avnav-daily:20250901` image
- Change port from 3011 to 8080
- Add host networking for better device discovery and multicast support
- Simplify volume structure to single `/var/lib/avnav` path
- Add MapProxy plugin for chart serving
- Add O-Charts support for commercial chart formats

## CI Changes
- Run tests only on pull requests (not on every push to main)

## Test plan
- [ ] Verify app installs successfully via Runtipi
- [ ] Confirm AvNav is accessible on port 8080
- [ ] Test host networking and device discovery
- [ ] Verify data persistence in new volume structure
- [ ] Run automated tests (will run automatically on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)