### PR TITLE
fix(avnav): switch to bridged networking to avoid port conflict

### DIFF
--- a/apps/avnav/config.json
+++ b/apps/avnav/config.json
@@ -4,7 +4,7 @@
   "available": true,
   "short_desc": "Open-source marine navigation software for chartplotting",
   "author": "Andreas Vogel",
-  "port": 8080,
+  "port": 3011,
   "categories": [
     "utilities",
     "network"

--- a/apps/avnav/docker-compose.json
+++ b/apps/avnav/docker-compose.json
@@ -5,7 +5,18 @@
       "image": "xfreex/avnav-daily:20250901",
       "isMain": true,
       "internalPort": "8080",
-      "networkMode": "host",
+      "ports": [
+        {
+          "hostPort": "3011",
+          "containerPort": "8080",
+          "protocol": "tcp"
+        },
+        {
+          "hostPort": "34567",
+          "containerPort": "34567",
+          "protocol": "tcp"
+        }
+      ],
       "privileged": true,
       "user": "1000:1000",
       "volumes": [


### PR DESCRIPTION
## Summary

- Switch AvNav from host networking to bridged networking
- Resolves port conflict with Traefik (both were using port 8080)
- Configure explicit port mappings: 3011:8080 and 34567:34567

## Changes

- **docker-compose.json**: Remove `networkMode: host`, add explicit port mappings
- **config.json**: Update port from 8080 to 3011 (external port)
- Keep privileged mode and /dev access for hardware device integration

## Test plan

- [x] Run `./run test:workflow` (all 30 tests passing)
- [ ] Deploy and verify web UI accessible on port 3011
- [ ] Verify no conflict with Traefik on port 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)