### PR TITLE
chore: update license from WTFPL to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,21 @@
-        DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
-                    Version 2, December 2004 
+MIT License
 
- Copyright (C) 2004 Sam Hocevar <sam@hocevar.net> 
+Copyright (c) 2025 The runtipi-marine-app-store contributors
 
- Everyone is permitted to copy and distribute verbatim or modified 
- copies of this license document, and changing it is allowed as long 
- as the name is changed. 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-  0. You just DO WHAT THE FUCK YOU WANT TO.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@types/bun": "latest",
     "@types/node": "^22.14.1"


### PR DESCRIPTION
## Summary

- Replace WTFPL license with standard MIT license
- Update package.json license field from ISC to MIT for consistency
- Use "The runtipi-marine-app-store contributors" as copyright holder

## Rationale

WTFPL is not a professional license choice for a production application store. MIT is a well-established, widely-recognized permissive open source license that:
- Provides clear legal terms
- Is compatible with most other licenses
- Is accepted by major organizations and platforms
- Maintains the permissive nature of the original license

## Changes

- **LICENSE**: Replace WTFPL with MIT license text
- **package.json**: Update license field from "ISC" to "MIT"

## Test plan

- [x] Run `./run test:workflow` (all tests passing)
- [x] Verify license text is standard MIT format

🤖 Generated with [Claude Code](https://claude.com/claude-code)