### PR TITLE
fix(avnav): adjust docker configuration, small documentation fixes

### DIFF
--- a/apps/avnav/config.json
+++ b/apps/avnav/config.json
@@ -11,7 +11,7 @@
   ],
   "description": "AvNav is a free and open-source navigation software designed for sailors and boaters. It provides a full-featured chartplotter with support for various chart formats, waypoint management, routing, and integration with marine data sources like Signal K. Includes mapproxy plugin for chart serving and o-charts support for commercial chart formats.",
   "tipi_version": 3,
-  "version": "20250901",
+  "version": "20251028",
   "source": "https://github.com/wellenvogel/avnav",
   "website": "https://www.wellenvogel.net/software/avnav/docs/",
   "exposable": true,

--- a/apps/avnav/docker-compose.json
+++ b/apps/avnav/docker-compose.json
@@ -2,13 +2,18 @@
   "services": [
     {
       "name": "avnav",
-      "image": "xfreex/avnav-daily:20250901",
+      "image": "xfreex/avnav-stable:20251028",
       "isMain": true,
       "internalPort": "8080",
       "ports": [
         {
           "hostPort": "3011",
           "containerPort": "8080",
+          "protocol": "tcp"
+        },
+        {
+          "hostPort": "8083",
+          "containerPort": "8083",
           "protocol": "tcp"
         },
         {

--- a/apps/avnav/metadata/description.md
+++ b/apps/avnav/metadata/description.md
@@ -67,7 +67,7 @@ The app has access to `/dev` for serial device connectivity.
 
 ## Documentation
 
-- **Official Documentation**: https://www.wellenvogel.net/software/avnav/docs/
+- **Official Documentation**: https://www.wellenvogel.net/software/avnav/docs/onepage.html?lang=en
 - **GitHub Repository**: https://github.com/wellenvogel/avnav
 - **Chart Sources**: Various free and commercial chart sources available
 


### PR DESCRIPTION
Hi @mairas ,

this PR adjust configuration of avnav-docker
- Using avnav-stable container
- Add port for ocharts-ng (8083)
- Small fix for AvNav documentation

Regards
free-x