### PR TITLE
feat(renovate): enhance automation with version constraints and fix signalk versioning

### DIFF
--- a/apps/signalk/config.json
+++ b/apps/signalk/config.json
@@ -11,7 +11,7 @@
   ],
   "description": "Signal K is a modern and open data format for marine use. A format for the modern boat, compatible with NMEA 2000 and NMEA 0183. The Signal K Server is a full-featured server that can act as a hub for all your boat's data, providing a websocket API, data logging, a web app server, and integration with various instruments and data sources.",
   "tipi_version": 3,
-  "version": "v24",
+  "version": "v2.17.2",
   "source": "https://github.com/SignalK/signalk-server",
   "website": "https://signalk.org/",
   "exposable": true,

--- a/apps/signalk/docker-compose.json
+++ b/apps/signalk/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "signalk",
-      "image": "signalk/signalk-server:v2.17.2-24.x",
+      "image": "signalk/signalk-server:v2.17.2",
       "isMain": true,
       "internalPort": "3000",
       "volumes": [


### PR DESCRIPTION
## Summary

This PR enhances the Renovate automation system and fixes version consistency for Signal K:

- **Add comprehensive Renovate documentation** in RENOVATE.md covering configuration, version constraints, and troubleshooting
- **Implement version constraints** for InfluxDB (2.7.x only) and OpenCPN (clean semver tags only)
- **Pin OpenCPN** to specific version 5.12.4 instead of "latest"
- **Fix Signal K versioning** to use consistent v2.17.2 across config.json and docker-compose.json

## Test Plan

- [ ] Verify Renovate configuration is valid (syntax check)
- [ ] Confirm OpenCPN version pinning works correctly
- [ ] Confirm Signal K version is consistent
- [ ] Test that version constraints work as expected in next Renovate run
- [ ] Review new documentation for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)