### PR TITLE
feat: migrate docker-compose files to schema v2

### DIFF
--- a/apps/avnav/docker-compose.json
+++ b/apps/avnav/docker-compose.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 2,
   "services": [
     {
       "name": "avnav",

--- a/apps/grafana/docker-compose.json
+++ b/apps/grafana/docker-compose.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://schemas.runtipi.io/dynamic-compose.json",
+  "schemaVersion": 2,
   "services": [
     {
       "name": "grafana",

--- a/apps/influxdb/docker-compose.json
+++ b/apps/influxdb/docker-compose.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 2,
   "services": [
     {
       "name": "influxdb",

--- a/apps/opencpn/docker-compose.json
+++ b/apps/opencpn/docker-compose.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 2,
   "services": [
     {
       "name": "opencpn",

--- a/apps/signalk/docker-compose.json
+++ b/apps/signalk/docker-compose.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 2,
   "services": [
     {
       "name": "signalk",


### PR DESCRIPTION
## Summary

Migrates all app docker-compose.json files to Runtipi schema v2 by adding the `schemaVersion: 2` field.

**Note:** The current version of @runtipi/common (v0.8.1) does not support the array format for environment variables documented in the migration guide. This PR applies the correct migration for the current schema version.

## Changes

- Add `"schemaVersion": 2` to all docker-compose.json files (grafana, influxdb, avnav, opencpn, signalk)
- Keep environment variables in object format: `Record<string, string | number>`
- Preserve original data types (numbers stay numbers, strings stay strings)

## Benefits

- Declares explicit schema version for better validation
- Aligns with Runtipi's recommended best practices
- No functional changes to app behavior

## Testing

- All tests pass locally and in CI
- Schema validation confirms correct format

## References

- [Runtipi Dynamic Compose Migration Guide](https://runtipi.io/docs/guides/dynamic-compose-guide#migrating-from-schema-v1-to-v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)