### PR TITLE
fix(schema): convert environment to array format for schema v2

### DIFF
--- a/apps/avnav/docker-compose.json
+++ b/apps/avnav/docker-compose.json
@@ -35,10 +35,10 @@
           "containerPath": "/dev"
         }
       ],
-      "environment": {
-        "UID": 1000,
-        "GID": 1000
-      }
+      "environment": [
+        { "key": "UID", "value": 1000 },
+        { "key": "GID", "value": 1000 }
+      ]
     }
   ]
 }

--- a/apps/influxdb/docker-compose.json
+++ b/apps/influxdb/docker-compose.json
@@ -6,16 +6,16 @@
       "image": "influxdb:2.7.11",
       "isMain": true,
       "internalPort": "8086",
-      "environment": {
-        "DOCKER_INFLUXDB_INIT_MODE": "setup",
-        "DOCKER_INFLUXDB_INIT_USERNAME": "${DOCKER_INFLUXDB_INIT_USERNAME}",
-        "DOCKER_INFLUXDB_INIT_PASSWORD": "${DOCKER_INFLUXDB_INIT_PASSWORD}",
-        "DOCKER_INFLUXDB_INIT_ORG": "${DOCKER_INFLUXDB_INIT_ORG}",
-        "DOCKER_INFLUXDB_INIT_BUCKET": "${DOCKER_INFLUXDB_INIT_BUCKET}",
-        "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN": "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}",
-        "DOCKER_INFLUXD_QUERY_CONCURRENCY": "1",
-        "DOCKER_INFLUXD_QUERY_MEMORY_BYTES": "20971520"
-      },
+      "environment": [
+        { "key": "DOCKER_INFLUXDB_INIT_MODE", "value": "setup" },
+        { "key": "DOCKER_INFLUXDB_INIT_USERNAME", "value": "${DOCKER_INFLUXDB_INIT_USERNAME}" },
+        { "key": "DOCKER_INFLUXDB_INIT_PASSWORD", "value": "${DOCKER_INFLUXDB_INIT_PASSWORD}" },
+        { "key": "DOCKER_INFLUXDB_INIT_ORG", "value": "${DOCKER_INFLUXDB_INIT_ORG}" },
+        { "key": "DOCKER_INFLUXDB_INIT_BUCKET", "value": "${DOCKER_INFLUXDB_INIT_BUCKET}" },
+        { "key": "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", "value": "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}" },
+        { "key": "DOCKER_INFLUXD_QUERY_CONCURRENCY", "value": "1" },
+        { "key": "DOCKER_INFLUXD_QUERY_MEMORY_BYTES", "value": "20971520" }
+      ],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/config",

--- a/apps/opencpn/docker-compose.json
+++ b/apps/opencpn/docker-compose.json
@@ -15,10 +15,10 @@
       "extraHosts": [
         "host.docker.internal:host-gateway"
       ],
-      "environment": {
-        "TITLE": "OpenCPN",
-        "SELKIES_ENABLE_RESIZE": "true"
-      },
+      "environment": [
+        { "key": "TITLE", "value": "OpenCPN" },
+        { "key": "SELKIES_ENABLE_RESIZE", "value": "true" }
+      ],
       "shmSize": "1gb"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^22.14.1"
   },
   "dependencies": {
-    "@runtipi/common": "^0.8.0",
+    "@runtipi/common": "^1.0.1",
     "bun": "^1.2.10",
     "zod-validation-error": "^3.4.0"
   },


### PR DESCRIPTION
## Summary
- Convert environment variables from object format to array format for `schemaVersion: 2`
- Update `@runtipi/common` from v0.8.0 to v1.0.1 to match current schema specification
- Fix installation errors for InfluxDB, AvNav, and OpenCPN apps

## Background
The official Runtipi schema v2 requires environment variables in array format: `[{"key": "VAR", "value": "val"}]`, but the apps were using the old object format which caused validation errors during installation.

## Changes
- **apps/influxdb/docker-compose.json**: Convert 8 environment variables to array format
- **apps/avnav/docker-compose.json**: Convert 2 environment variables to array format  
- **apps/opencpn/docker-compose.json**: Convert 2 environment variables to array format
- **package.json**: Upgrade `@runtipi/common` to v1.0.1

## Test plan
- [x] Run `./run test:workflow` to validate schema compliance
- [ ] Test InfluxDB installation in Runtipi
- [ ] Test AvNav installation in Runtipi
- [ ] Test OpenCPN installation in Runtipi

🤖 Generated with [Claude Code](https://claude.com/claude-code)